### PR TITLE
Improve README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,15 @@ RspecSequel::Matchers has an extensive test suite and will give you as much expl
 
   sudo gem install openhood-rspec_sequel_matchers
 
+== Config
+
+  In spec_helper.rb
+
+    RSpec.configure do |config|
+      config.include RspecSequel::Matchers
+      # ... other config ...
+    end
+
 == Example usage
 
   describe Item do


### PR DESCRIPTION
Hey,
I was using your gem on a project and had a bit of trouble getting it to work. It was a mistake on my part, because I hadn't configured RSpec to use RspecSequel::Matchers. Anyway, I thought it might be a good idea to include it in the README, so noobs like me don't make the same mistake ;)

Thanks!
