### PR TITLE
Utilise ActiveSupport inflector if available

### DIFF
--- a/lib/rspec_sequel/base.rb
+++ b/lib/rspec_sequel/base.rb
@@ -1,5 +1,5 @@
 require "sequel"
-require "sequel/extensions/inflector"
+require "sequel/extensions/inflector" unless ''.respond_to?(:classify)
 require "rspec/mocks"
 require "rspec/mocks/example_methods"
 


### PR DESCRIPTION
By specifically requiring the Sequel inflector extension any changes to
a rails based project in config/initializers/inflections.rb where being
silently (and frustratingly) discarded.
